### PR TITLE
Add libhandy depenedency to Arch install

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ python3 main.py
 
 Install the dependencies:
 ```bash
-sudo pacman -S binutils wget curl git python-pip libappindicator-gtk3 usbmuxd libimobiledevice avahi zlib unzip usbutils
+sudo pacman -S binutils wget curl git python-pip libappindicator-gtk3 usbmuxd libimobiledevice avahi zlib unzip usbutils libhandy
 ```
 
 Clone and build:


### PR DESCRIPTION
Script will not run without libhandy installed, so this PR adds that to the readme

```
❯ python3 main.py
Traceback (most recent call last):
  File "/home/aiden/Documents/repos/SideServer-for-Linux/main.py", line 16, in <module>
    gi.require_version("Handy", "1")
  File "/usr/lib/python3.12/site-packages/gi/__init__.py", line 122, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Handy not available
```

I promise I'm not contribution farming 🙃